### PR TITLE
Replace default test with homepage title check

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders game title', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  expect(screen.getByText(/^Deal or No Deal!$/i)).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- update App.test.js to assert that the homepage renders "Deal or No Deal!"

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6893633987088329822c3514300a3236