### PR TITLE
Handle role-specific league views

### DIFF
--- a/src/components/league.js
+++ b/src/components/league.js
@@ -1,5 +1,5 @@
-import React, { useEffect, useRef, useState } from "react";
-import { useParams } from "react-router-dom";
+import React, { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
 import { auth, db } from "../firebase-config";
 import { doc, onSnapshot } from "firebase/firestore";
 import { onAuthStateChanged } from "firebase/auth";
@@ -9,59 +9,81 @@ const League = () => {
 
   let { leagueId } = useParams()
 
-  const [user, setUser] = useState({})
+  const [user, setUser] = useState(null)
   const [league, setLeague] = useState({})
-  
+  const [member, setMember] = useState(null)
 
-  
-  const leagueRef = doc(db, "leagues", leagueId )
+  const leagueRef = doc(db, "leagues", leagueId)
 
-  
-
-  
   useEffect(() => {
-    onAuthStateChanged(auth, (currentUser) => {
-      setUser(currentUser);
-    });
-
-    const unsub = onSnapshot(leagueRef, (doc) => {
-      setLeague(doc.data())
-    }, 
-    (error) => {
-      console.log(error)
+    const authUnsub = onAuthStateChanged(auth, (currentUser) => {
+      setUser(currentUser)
     })
 
+    const leagueUnsub = onSnapshot(
+      leagueRef,
+      (doc) => {
+        setLeague(doc.data())
+      },
+      (error) => {
+        console.log(error)
+      }
+    )
+
     return () => {
-      unsub()
+      authUnsub()
+      leagueUnsub()
     }
-    
-  }, [])
+  }, [leagueRef])
 
-
-
+  useEffect(() => {
+    if (!user?.uid) return
+    const memberRef = doc(db, "leagues", leagueId, "members", user.uid)
+    const unsub = onSnapshot(
+      memberRef,
+      (doc) => {
+        setMember(doc.data())
+      },
+      (error) => {
+        console.log(error)
+      }
+    )
+    return () => unsub()
+  }, [user, leagueId])
 
   return (
     <div className="league-panel">
-    <h2>{league.name}</h2>
+      <h2>{league.name}</h2>
 
-    {user && user.uid === league.uid && (
-      <div>
-        <p>Access Code: {league.accessCode}</p>
-        <p>URL: /league/{leagueId}</p>
-        
-        <h4>Seasons:</h4>
-        <Seasons league={league} leagueId={leagueId} leagueRef={leagueRef} />
-      </div>
-    )}
+      {member?.role === "admin" && (
+        <div>
+          <p>Access Code: {league.accessCode}</p>
+          <p>URL: /league/{leagueId}</p>
+          <h4>Seasons:</h4>
+          <Seasons league={league} leagueId={leagueId} leagueRef={leagueRef} />
+        </div>
+      )}
 
-    {!user || user.uid != league.uid && (
-      <div>
-        Stuff for code users
-      </div>
-    )}
-    
+      {member?.role === "player" && (
+        <div>
+          <p>Access Code: {league.accessCode}</p>
+          <p>Lineup Status: {member.lineupStatus || "Not set"}</p>
+          {league.currentSeason && league.currentWeek && (
+            <Link
+              to="/game/setting-lineups"
+              state={{
+                leagueId: leagueId,
+                season: league.currentSeason,
+                week: league.currentWeek,
+              }}
+            >
+              <button>Go To Weekly Game</button>
+            </Link>
+          )}
+        </div>
+      )}
     </div>
   )
 }
 
-export default League
+  export default League


### PR DESCRIPTION
## Summary
- Determine a member's role by reading their `members/{uid}` document
- Render season and week management for league admins only
- Show access code, lineup status, and game navigation for players

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68937709b2988329a7d791a603161989