### PR TITLE
Refactor game to single user and persist lineup

### DIFF
--- a/src/components/entries.js
+++ b/src/components/entries.js
@@ -113,16 +113,6 @@ const Entries = ({ leagueId, season, week, actualWeek }) => {
         <Link
           to="/game/setting-lineups"
           state={{
-            contestants: [
-              {
-                name: user.uid,
-                lineUp: {
-                  RB: { name: "awaiting game..." },
-                  WR: { name: "awaiting game..." },
-                  finalScore: null,
-                },
-              },
-            ],
             leagueId: leagueId,
             season: season,
             week: week,


### PR DESCRIPTION
## Summary
- simplify game flow to single authenticated user and remove multi-contestant logic
- save RB/WR selections under user's entry document and return to week page
- streamline entries link to pass only league/season/week

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68937fc280bc83298eaf0c079573f873