### PR TITLE
Add group game flow for multiple participants

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import Error from './components/error';
 import Dashboard from './components/dashboard';
 import League from './components/league';
 import Game from './components/game';
+import GroupGame from './components/groupGame';
 
 
 
@@ -25,6 +26,7 @@ function App() {
           <Route path="/login" element={<SignUp />} />
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/league/:leagueId" element={<League />} />
+          <Route path="/game/group" element={<GroupGame />} />
           <Route path="/game/:type" element={<Game />} />
           <Route path="*" element={<Error />} />
         </Routes>

--- a/src/components/entries.js
+++ b/src/components/entries.js
@@ -161,7 +161,7 @@ const Entries = ({ leagueId, season, week, actualWeek }) => {
             leagueId: leagueId,
             season: season,
             week: week,
-            uids: selectedUids,
+            participants: selectedUids,
           }}
         >
           <button disabled={selectedUids.length === 0}>Start Group Game</button>

--- a/src/components/game.js
+++ b/src/components/game.js
@@ -4,12 +4,12 @@ import { auth, db } from "../firebase-config";
 import { doc, setDoc } from "firebase/firestore";
 import { getPlayers, generateCases } from './util';
 
-const Game = () => {
+const Game = ({ uid, onComplete }) => {
 
 
   const { leagueId, season, week } = useLocation().state
-  const user = auth.currentUser
   const navigate = useNavigate()
+  const currentUid = uid || auth.currentUser?.uid
 
   const [cases, setCases] = useState(null)
   const [caseSelected, setCaseSelected] = useState(null)
@@ -263,12 +263,16 @@ const Game = () => {
   }
 
   const submitLineup = async () => {
-    const docRef = doc(db, "leagues", leagueId, "seasons", season, "weeks", week, "entries", user.uid)
+    const docRef = doc(db, "leagues", leagueId, "seasons", season, "weeks", week, "entries", currentUid)
     await setDoc(docRef, {
-      name: user.uid,
+      name: currentUid,
       lineUp: lineUp
     })
-    navigate(-1)
+    if(onComplete) {
+      onComplete()
+    } else {
+      navigate(-1)
+    }
   }
 
 
@@ -483,7 +487,7 @@ const Game = () => {
 
   return (
     <>
-      <h3>Current User: {user?.uid}</h3>
+      <h3>Current User: {currentUid}</h3>
       <div className="game">
         <div className="board">
           {render()}
@@ -495,7 +499,7 @@ const Game = () => {
       </div>
       <div className="contestant-flexbox">
         <div className="contestant-card">
-          <p>{user?.uid}</p>
+          <p>{currentUid}</p>
           <p><b>RB:</b> {lineUp.RB.name}</p>
           <p><b>WR:</b> {lineUp.WR.name}</p>
         </div>

--- a/src/components/groupGame.js
+++ b/src/components/groupGame.js
@@ -1,0 +1,27 @@
+import React, { useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import Game from "./game";
+
+const GroupGame = () => {
+  const navigate = useNavigate();
+  const { leagueId, season, week, participants } = useLocation().state;
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const handleComplete = () => {
+    if (currentIndex < participants.length - 1) {
+      setCurrentIndex((idx) => idx + 1);
+    } else {
+      navigate(-1);
+    }
+  };
+
+  return (
+    <Game
+      key={participants[currentIndex]}
+      uid={participants[currentIndex]}
+      onComplete={handleComplete}
+    />
+  );
+};
+
+export default GroupGame;


### PR DESCRIPTION
## Summary
- Support multi-player lineup selection via new `GroupGame` wrapper
- Enable `Game` component to accept arbitrary participant ids and callback
- Adjust entries link and routing to start group games

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68938dde3d2883298b02596e722065ee