### PR TITLE
Use current user uid for single-player game and hide play option when entry exists

### DIFF
--- a/src/components/entries.js
+++ b/src/components/entries.js
@@ -27,7 +27,7 @@ const Entries = ({ leagueId, season, week, actualWeek }) => {
     return member?.uid || id;
   };
 
-  const hasEntry = entries?.some((entry) => entry.id === user?.uid);
+  const hasEntry = !!entries?.some((entry) => entry.id === user?.uid);
 
   const currentMember = members?.find((m) => m.id === user?.uid);
   const isAdmin = currentMember?.role === "admin";
@@ -142,7 +142,7 @@ const Entries = ({ leagueId, season, week, actualWeek }) => {
           ))}
         </tbody>
       </table>
-      {!hasEntry && user && (
+      {entries && !hasEntry && user && (
         <Link
           to="/game/setting-lineups"
           state={{

--- a/src/components/game.js
+++ b/src/components/game.js
@@ -4,12 +4,13 @@ import { auth, db } from "../firebase-config";
 import { doc, setDoc } from "firebase/firestore";
 import { getPlayers, generateCases } from './util';
 
-const Game = ({ uid, onComplete }) => {
+// Single-player game that always uses the currently logged-in user's UID
+const Game = () => {
 
 
   const { leagueId, season, week } = useLocation().state
   const navigate = useNavigate()
-  const currentUid = uid || auth.currentUser?.uid
+  const currentUid = auth.currentUser?.uid
 
   const [cases, setCases] = useState(null)
   const [caseSelected, setCaseSelected] = useState(null)
@@ -268,11 +269,7 @@ const Game = ({ uid, onComplete }) => {
       name: currentUid,
       lineUp: lineUp
     })
-    if(onComplete) {
-      onComplete()
-    } else {
-      navigate(-1)
-    }
+    navigate(-1)
   }
 
 


### PR DESCRIPTION
## Summary
- Refactor game component to always use the logged-in user's UID and simplify lineup submission.
- Only display the "Play Game" button on week pages when the logged-in user has no entry.

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68939111f96483299c7a9658220eee3a