### PR TITLE
Add tests for Dashboard league creation

### DIFF
--- a/src/components/__tests__/dashboard.test.js
+++ b/src/components/__tests__/dashboard.test.js
@@ -1,0 +1,84 @@
+jest.mock('uuid', () => ({ v4: jest.fn() }));
+
+jest.mock('firebase/firestore', () => ({
+  addDoc: jest.fn(),
+  setDoc: jest.fn(),
+  collection: jest.fn(() => 'leaguesRef'),
+  doc: jest.fn(() => 'memberRef'),
+  getDocs: jest.fn(),
+  onSnapshot: jest.fn(() => () => {}),
+  query: jest.fn(() => 'query'),
+  where: jest.fn(() => 'where'),
+  collectionGroup: jest.fn(() => 'membersQuery'),
+  getDoc: jest.fn(),
+}));
+
+jest.mock('firebase/auth', () => ({
+  onAuthStateChanged: jest.fn(),
+  signOut: jest.fn(),
+}));
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => jest.fn(),
+  };
+});
+
+jest.mock('../../firebase-config', () => ({
+  auth: {},
+  db: {},
+}));
+
+const { render, screen, waitFor } = require('@testing-library/react');
+const userEvent = require('@testing-library/user-event').default;
+const { MemoryRouter } = require('react-router-dom');
+const { v4: uuidv4 } = require('uuid');
+const { addDoc, setDoc, onSnapshot, doc } = require('firebase/firestore');
+const { onAuthStateChanged } = require('firebase/auth');
+const Dashboard = require('../dashboard').default;
+
+onSnapshot.mockReturnValue(() => {});
+doc.mockReturnValue('memberRef');
+
+test('creates league and adds owner as admin', async () => {
+  const mockUser = { uid: 'user123' };
+  uuidv4.mockReturnValue('access-code');
+  addDoc.mockResolvedValue({ id: 'league123' });
+  setDoc.mockResolvedValue();
+  onAuthStateChanged.mockImplementation((auth, callback) => {
+    callback(mockUser);
+    return () => {};
+  });
+
+  render(
+    <MemoryRouter>
+      <Dashboard />
+    </MemoryRouter>
+  );
+
+  await userEvent.click(screen.getByText('Create League'));
+  await userEvent.type(
+    screen.getByPlaceholderText('Enter League Name...'),
+    'Test League'
+  );
+  await userEvent.click(screen.getByText('Submit'));
+
+  await waitFor(() => {
+    expect(addDoc).toHaveBeenCalled();
+    expect(setDoc).toHaveBeenCalled();
+  });
+
+  expect(addDoc.mock.calls[0][1]).toEqual({
+    name: 'Test League',
+    uid: mockUser.uid,
+    accessCode: 'access-code',
+  });
+
+  expect(setDoc.mock.calls[0][1]).toEqual({
+    uid: mockUser.uid,
+    role: 'admin',
+  });
+});
+

--- a/src/components/dashboard.js
+++ b/src/components/dashboard.js
@@ -94,7 +94,7 @@ const Dashboard = () => {
       }
     );
 
-    return () => unsub();
+    return () => unsub && unsub();
   }, [user]);
 
   const logout = async () => {


### PR DESCRIPTION
## Summary
- add test for creating a league and assigning owner as admin
- make Dashboard's snapshot cleanup resilient when subscription is missing

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6893985519788329b23c74cdb1e4ea23