### PR TITLE
test: verify lineup submission

### DIFF
--- a/src/components/__tests__/game.test.js
+++ b/src/components/__tests__/game.test.js
@@ -1,0 +1,57 @@
+jest.mock('firebase/firestore', () => ({
+  doc: jest.fn(),
+  setDoc: jest.fn(),
+}));
+
+jest.mock('../../firebase-config', () => ({
+  auth: { currentUser: { uid: 'uid-123' } },
+  db: {},
+}));
+
+jest.mock('react-router-dom', () => ({
+  useLocation: () => ({ state: { leagueId: 'league1', season: '2023', week: '1' } }),
+  useNavigate: () => jest.fn(),
+}));
+
+jest.mock('../util', () => ({
+  getPlayers: jest.fn(),
+  generateCases: jest.fn(),
+}));
+
+const { render, screen } = require('@testing-library/react');
+const userEvent = require('@testing-library/user-event').default;
+const React = require('react');
+const { doc, setDoc } = require('firebase/firestore');
+
+test('submits lineup with current user uid', async () => {
+  const dummyLineUp = {
+    RB: { name: 'rb-player' },
+    WR: { name: 'wr-player' },
+  };
+
+  doc.mockReturnValue('docRef');
+  setDoc.mockResolvedValue();
+
+  const useStateSpy = jest.spyOn(React, 'useState');
+  let call = 0;
+  useStateSpy.mockImplementation((initial) => {
+    call++;
+    if (call === 11) return [true, jest.fn()]; // finished
+    if (call === 12) return [true, jest.fn()]; // midway
+    if (call === 16) return [dummyLineUp, jest.fn()]; // lineUp
+    return [initial, jest.fn()];
+  });
+
+  const Game = require('../game').default;
+  render(<Game />);
+
+  await userEvent.click(screen.getAllByText('Submit Lineup')[0]);
+
+  expect(setDoc).toHaveBeenCalledWith('docRef', {
+    name: 'uid-123',
+    lineUp: dummyLineUp,
+  });
+
+  useStateSpy.mockRestore();
+});
+


### PR DESCRIPTION
## Summary
- add unit test for game lineup submission

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68939df5ceb88329945e2bb75e587a0d