### PR TITLE
feat: allow custom uid for game

### DIFF
--- a/src/components/__tests__/game.test.js
+++ b/src/components/__tests__/game.test.js
@@ -23,16 +23,28 @@ const userEvent = require('@testing-library/user-event').default;
 const React = require('react');
 const { doc, setDoc } = require('firebase/firestore');
 
+const useStateSpy = jest.spyOn(React, 'useState');
+const Game = require('../game').default;
+
+afterEach(() => {
+  useStateSpy.mockReset();
+});
+
+afterAll(() => {
+  useStateSpy.mockRestore();
+});
+
 test('submits lineup with current user uid', async () => {
   const dummyLineUp = {
     RB: { name: 'rb-player' },
     WR: { name: 'wr-player' },
   };
 
+  doc.mockClear();
+  setDoc.mockClear();
   doc.mockReturnValue('docRef');
   setDoc.mockResolvedValue();
 
-  const useStateSpy = jest.spyOn(React, 'useState');
   let call = 0;
   useStateSpy.mockImplementation((initial) => {
     call++;
@@ -42,7 +54,6 @@ test('submits lineup with current user uid', async () => {
     return [initial, jest.fn()];
   });
 
-  const Game = require('../game').default;
   render(<Game />);
 
   await userEvent.click(screen.getAllByText('Submit Lineup')[0]);
@@ -52,6 +63,36 @@ test('submits lineup with current user uid', async () => {
     lineUp: dummyLineUp,
   });
 
-  useStateSpy.mockRestore();
+});
+
+test('submits lineup with provided uid', async () => {
+  const dummyLineUp = {
+    RB: { name: 'rb-player' },
+    WR: { name: 'wr-player' },
+  };
+
+  doc.mockClear();
+  setDoc.mockClear();
+  doc.mockReturnValue('docRef');
+  setDoc.mockResolvedValue();
+
+  let call = 0;
+  useStateSpy.mockImplementation((initial) => {
+    call++;
+    if (call === 11) return [true, jest.fn()]; // finished
+    if (call === 12) return [true, jest.fn()]; // midway
+    if (call === 16) return [dummyLineUp, jest.fn()]; // lineUp
+    return [initial, jest.fn()];
+  });
+
+  render(<Game uid="custom-uid" />);
+
+  await userEvent.click(screen.getAllByText('Submit Lineup')[0]);
+
+  expect(setDoc).toHaveBeenCalledWith('docRef', {
+    name: 'custom-uid',
+    lineUp: dummyLineUp,
+  });
+
 });
 

--- a/src/components/game.js
+++ b/src/components/game.js
@@ -4,13 +4,13 @@ import { auth, db } from "../firebase-config";
 import { doc, setDoc } from "firebase/firestore";
 import { getPlayers, generateCases } from './util';
 
-// Single-player game that always uses the currently logged-in user's UID
-const Game = () => {
+// Game component that can accept a specific uid or default to the current user
+const Game = ({ uid, onComplete }) => {
 
 
   const { leagueId, season, week } = useLocation().state
   const navigate = useNavigate()
-  const currentUid = auth.currentUser?.uid
+  const currentUid = uid || auth.currentUser?.uid
 
   const [cases, setCases] = useState(null)
   const [caseSelected, setCaseSelected] = useState(null)
@@ -269,7 +269,11 @@ const Game = () => {
       name: currentUid,
       lineUp: lineUp
     })
-    navigate(-1)
+    if(onComplete) {
+      onComplete()
+    } else {
+      navigate(-1)
+    }
   }
 
 


### PR DESCRIPTION
## Summary
- support optional uid prop in `Game` component
- call optional `onComplete` after lineup submission
- test lineup submission with default and custom uids

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68939ffef6488329b550d2fc85c0df0d