### PR TITLE
test: add GroupGame participant submission test

### DIFF
--- a/src/components/__tests__/groupGame.test.js
+++ b/src/components/__tests__/groupGame.test.js
@@ -1,0 +1,41 @@
+jest.mock('firebase/firestore', () => ({
+  setDoc: jest.fn(),
+}));
+
+const participants = ['uid-1', 'uid-2', 'uid-3'];
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  useLocation: () => ({
+    state: { leagueId: 'league1', season: '2023', week: '1', participants },
+  }),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../game', () => {
+  const React = require('react');
+  const { setDoc } = require('firebase/firestore');
+  return {
+    __esModule: true,
+    default: ({ uid, onComplete }) => {
+      React.useEffect(() => {
+        setDoc(uid, {});
+        onComplete();
+      }, [uid, onComplete]);
+      return null;
+    },
+  };
+});
+
+const React = require('react');
+const { render, waitFor } = require('@testing-library/react');
+const { setDoc } = require('firebase/firestore');
+const GroupGame = require('../groupGame').default;
+
+test('submits lineup for each participant and navigates after completion', async () => {
+  render(<GroupGame />);
+
+  await waitFor(() => expect(setDoc).toHaveBeenCalledTimes(participants.length));
+  expect(setDoc.mock.calls.map((call) => call[0])).toEqual(participants);
+  await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith(-1));
+});


### PR DESCRIPTION
## Summary
- add GroupGame test to ensure sequential lineup submission and navigation

## Testing
- `npm test src/components/__tests__/groupGame.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6893a242bef883299ac0bb031fa890e1