### PR TITLE
Include member display info in leagues and improve entry labels

### DIFF
--- a/src/components/__tests__/dashboard.test.js
+++ b/src/components/__tests__/dashboard.test.js
@@ -50,7 +50,7 @@ onSnapshot.mockReturnValue(() => {});
 doc.mockReturnValue('memberRef');
 
 test('creates league and adds owner as admin', async () => {
-  const mockUser = { uid: 'user123' };
+  const mockUser = { uid: 'user123', displayName: 'User One', email: 'user1@example.com' };
   uuidv4.mockReturnValue('access-code');
   addDoc.mockResolvedValue({ id: 'league123' });
   setDoc.mockResolvedValue();
@@ -86,13 +86,15 @@ test('creates league and adds owner as admin', async () => {
   expect(setDoc.mock.calls[0][1]).toEqual({
     uid: mockUser.uid,
     role: 'admin',
+    displayName: mockUser.displayName,
+    email: mockUser.email,
   });
 });
 
 test('joins league and adds user as player when access code matches', async () => {
   jest.clearAllMocks();
   doc.mockReturnValue('memberRef');
-  const mockUser = { uid: 'user123' };
+  const mockUser = { uid: 'user123', displayName: 'User One', email: 'user1@example.com' };
   onAuthStateChanged.mockImplementation((auth, callback) => {
     callback(mockUser);
     return () => {};
@@ -121,6 +123,8 @@ test('joins league and adds user as player when access code matches', async () =
     expect(setDoc).toHaveBeenCalledWith('memberRef', {
       uid: mockUser.uid,
       role: 'player',
+      displayName: mockUser.displayName,
+      email: mockUser.email,
     });
   });
 });

--- a/src/components/__tests__/entries.test.js
+++ b/src/components/__tests__/entries.test.js
@@ -14,6 +14,7 @@ jest.mock('react-firebase-hooks/firestore', () => ({
 }));
 
 const { render, screen, waitFor } = require('@testing-library/react');
+require('@testing-library/jest-dom');
 const userEvent = require('@testing-library/user-event').default;
 const { MemoryRouter } = require('react-router-dom');
 const { setDoc, doc } = require('firebase/firestore');
@@ -77,4 +78,31 @@ test('calculateScores sums player scores and persists finalScore', async () => {
       finalScore: entry.finalScore,
     });
   });
+});
+
+test('memberLabel prioritizes displayName then email then id', () => {
+  const entriesData = [
+    { id: 'user1', lineUp: {} },
+    { id: 'user2', lineUp: {} },
+    { id: 'user3', lineUp: {} },
+  ];
+  const members = [
+    { id: 'user1', uid: 'user1', displayName: 'Display One', email: 'one@example.com' },
+    { id: 'user2', uid: 'user2', email: 'two@example.com' },
+    { id: 'user3', uid: 'user3' },
+  ];
+
+  useCollectionData
+    .mockReturnValueOnce([entriesData])
+    .mockReturnValueOnce([members]);
+
+  render(
+    <MemoryRouter>
+      <Entries leagueId="league1" season="2023" week="1" actualWeek={1} />
+    </MemoryRouter>
+  );
+
+  expect(screen.getByText('Display One')).toBeInTheDocument();
+  expect(screen.getByText('two@example.com')).toBeInTheDocument();
+  expect(screen.getByText('user3')).toBeInTheDocument();
 });

--- a/src/components/dashboard.js
+++ b/src/components/dashboard.js
@@ -38,7 +38,12 @@ const Dashboard = () => {
       });
 
       const memberRef = doc(db, "leagues", newLeagueRef.id, "members", user.uid);
-      await setDoc(memberRef, { uid: user.uid, role: "admin" });
+      await setDoc(memberRef, {
+        uid: user.uid,
+        role: "admin",
+        displayName: user.displayName,
+        email: user.email,
+      });
 
       navigate(`/league/${newLeagueRef.id}`);
     } catch (error) {
@@ -53,7 +58,12 @@ const Dashboard = () => {
       if (!querySnapshot.empty) {
         const leagueDoc = querySnapshot.docs[0];
         const memberRef = doc(db, "leagues", leagueDoc.id, "members", user.uid);
-        await setDoc(memberRef, { uid: user.uid, role: "player" });
+        await setDoc(memberRef, {
+          uid: user.uid,
+          role: "player",
+          displayName: user.displayName,
+          email: user.email,
+        });
       }
     } catch (error) {
       console.log(error.message);

--- a/src/components/entries.js
+++ b/src/components/entries.js
@@ -24,7 +24,12 @@ const Entries = ({ leagueId, season, week, actualWeek }) => {
 
   const memberLabel = (id) => {
     const member = members?.find((m) => m.id === id);
-    return member?.uid || id;
+    return (
+      member?.displayName ||
+      member?.email ||
+      member?.uid ||
+      id
+    );
   };
 
   const hasEntry = !!entries?.some((entry) => entry.id === user?.uid);


### PR DESCRIPTION
## Summary
- Store `displayName` and `email` on league membership documents when creating or joining a league.
- Update entry label resolution to prefer `displayName` or `email`, falling back to the user id.
- Extend tests to cover new membership fields and label resolution.

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68940fc03b488329b5d6a24228515b07