### PR TITLE
feat: show projected RB/WR totals in entries table

### DIFF
--- a/src/components/__tests__/entries.test.js
+++ b/src/components/__tests__/entries.test.js
@@ -106,3 +106,36 @@ test('memberLabel prioritizes displayName then email then id', () => {
   expect(screen.getByText('two@example.com')).toBeInTheDocument();
   expect(screen.getByText('user3')).toBeInTheDocument();
 });
+
+test('renders projection columns and values', () => {
+  const entriesData = [
+    {
+      id: 'user1',
+      lineUp: {
+        RB: { name: 'RB1', points: 12 },
+        WR: { name: 'WR1', points: 8 },
+      },
+    },
+  ];
+  const members = [
+    { id: 'user1', uid: 'user1', displayName: 'User One' },
+    { id: 'admin1', uid: 'admin1', role: 'admin' },
+  ];
+
+  useCollectionData
+    .mockReturnValueOnce([entriesData])
+    .mockReturnValueOnce([members]);
+
+  render(
+    <MemoryRouter>
+      <Entries leagueId="league1" season="2023" week="1" actualWeek={1} />
+    </MemoryRouter>
+  );
+
+  expect(screen.getByText('RB Projection')).toBeInTheDocument();
+  expect(screen.getByText('WR Projection')).toBeInTheDocument();
+  expect(screen.getByText('Projected Total')).toBeInTheDocument();
+  expect(screen.getByText('12')).toBeInTheDocument();
+  expect(screen.getByText('8')).toBeInTheDocument();
+  expect(screen.getByText('20')).toBeInTheDocument();
+});

--- a/src/components/entries.js
+++ b/src/components/entries.js
@@ -50,6 +50,9 @@ const Entries = ({ leagueId, season, week, actualWeek }) => {
     ? [...entries].sort((a, b) => (b.finalScore || 0) - (a.finalScore || 0))
     : [];
 
+  const projectedTotal = (entry) =>
+    (entry.lineUp?.RB?.points ?? 0) + (entry.lineUp?.WR?.points ?? 0);
+
   const calculateScores = async () => {
     if (!entries) return;
     const rbUrl = `https://api.sleeper.com/stats/nfl/${season}/${week}?season_type=regular&position=RB&order_by=pts_ppr`;
@@ -127,7 +130,10 @@ const Entries = ({ leagueId, season, week, actualWeek }) => {
           <tr>
             <th className="p-2 border-b border-[#3a465b]">Member</th>
             <th className="p-2 border-b border-[#3a465b]">RB</th>
+            <th className="p-2 border-b border-[#3a465b]">RB Projection</th>
             <th className="p-2 border-b border-[#3a465b]">WR</th>
+            <th className="p-2 border-b border-[#3a465b]">WR Projection</th>
+            <th className="p-2 border-b border-[#3a465b]">Projected Total</th>
             <th className="p-2 border-b border-[#3a465b]">Final Score</th>
           </tr>
         </thead>
@@ -146,7 +152,10 @@ const Entries = ({ leagueId, season, week, actualWeek }) => {
                 {memberLabel(entry.id)}
               </td>
               <td className="p-2 border-b border-[#3a465b]">{entry.lineUp?.RB?.name ?? ""}</td>
+              <td className="p-2 border-b border-[#3a465b]">{entry.lineUp?.RB?.points ?? 0}</td>
               <td className="p-2 border-b border-[#3a465b]">{entry.lineUp?.WR?.name ?? ""}</td>
+              <td className="p-2 border-b border-[#3a465b]">{entry.lineUp?.WR?.points ?? 0}</td>
+              <td className="p-2 border-b border-[#3a465b]">{projectedTotal(entry)}</td>
               <td className="p-2 border-b border-[#3a465b]">{entry.finalScore ?? ""}</td>
             </tr>
           ))}


### PR DESCRIPTION
## Summary
- display projected RB and WR points in entries table
- add helper to compute projected totals per entry
- test coverage for new projected columns

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_689411d5c04c83299439bc6bf12d9e7c