### PR TITLE
chore: override svgo to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,10 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "overrides": {
+    "@svgr/webpack": "^6.5.1",
+    "@svgr/plugin-svgo": "^6.5.1",
+    "svgo": "^2.8.0"
   }
 }


### PR DESCRIPTION
## Summary
- enforce svgo 2.x with overrides for `@svgr/webpack` and `@svgr/plugin-svgo`

## Testing
- `npm install` *(fails: 403 Forbidden retrieving call-bind)*

------
https://chatgpt.com/codex/tasks/task_e_68941654e9888329beb6919948b5e5e8