### PR TITLE
Add auth-aware navigation bar and footer

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from 'react'
-import './App.css'
-import { BrowserRouter as Router, Routes, Route} from 'react-router-dom'
+import React from 'react';
+import './App.css';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Home from './components/home';
 import SignUp from './components/signIn';
 import Error from './components/error';
@@ -9,29 +9,27 @@ import League from './components/league';
 import Game from './components/game';
 import GroupGame from './components/groupGame';
 import Weeks from './components/weeks';
-
-
+import Navbar from './components/navbar';
+import Footer from './components/footer';
 
 function App() {
-  
-  
-
   return (
-    <div className="App">
+    <div className="App flex flex-col min-h-screen">
       <Router>
-        <h3>Deal or No Deal!</h3>
-        <h4>Fantasy Football Edition</h4>
-        <hr />
-        <Routes>
-          <Route path="/" element={<Home />}/>
-          <Route path="/login" element={<SignUp />} />
-          <Route path="/dashboard" element={<Dashboard />} />
-          <Route path="/league/:leagueId" element={<League />} />
-          <Route path="/league/:leagueId/season/:season" element={<Weeks />} />
-          <Route path="/game/group" element={<GroupGame />} />
-          <Route path="/game/:type" element={<Game />} />
-          <Route path="*" element={<Error />} />
-        </Routes>
+        <Navbar />
+        <div className="flex-grow">
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/login" element={<SignUp />} />
+            <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/league/:leagueId" element={<League />} />
+            <Route path="/league/:leagueId/season/:season" element={<Weeks />} />
+            <Route path="/game/group" element={<GroupGame />} />
+            <Route path="/game/:type" element={<Game />} />
+            <Route path="*" element={<Error />} />
+          </Routes>
+        </div>
+        <Footer />
       </Router>
     </div>
   );

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import App from './App';
 
-test('renders game title', () => {
+test('renders navigation bar', () => {
   render(<App />);
-  expect(screen.getByText(/^Deal or No Deal!$/i)).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: /home/i })).toBeInTheDocument();
 });

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function Footer() {
+  return (
+    <footer className="bg-gray-800 text-center py-4">
+      <p>&copy; 2025 DOND.FF</p>
+      <p>A PDC.ai creation</p>
+    </footer>
+  );
+}
+
+export default Footer;

--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { onAuthStateChanged, signOut } from 'firebase/auth';
+import { auth } from '../firebase-config';
+
+function Navbar() {
+  const [user, setUser] = useState(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (current) => {
+      setUser(current);
+    });
+    return () => unsubscribe();
+  }, []);
+
+  const logout = async () => {
+    await signOut(auth);
+    navigate('/');
+  };
+
+  return (
+    <nav className="flex justify-between items-center bg-gray-800 p-4">
+      <div className="flex space-x-4">
+        <Link to="/" className="font-bold hover:text-emerald-400">
+          Home
+        </Link>
+        {user && (
+          <Link to="/dashboard" className="font-bold hover:text-emerald-400">
+            Dashboard
+          </Link>
+        )}
+      </div>
+      <div className="flex items-center space-x-4">
+        {!user ? (
+          <>
+            <Link
+              to="/login"
+              className="px-4 py-2 bg-emerald-500 hover:bg-emerald-400 text-gray-900 font-bold rounded"
+            >
+              Sign In
+            </Link>
+            <Link
+              to="/login"
+              className={
+                "px-4 py-2 border-2 border-emerald-500 text-emerald-500 font-bold rounded " +
+                "hover:bg-emerald-500 hover:text-gray-900"
+              }
+            >
+              Create Account
+            </Link>
+          </>
+        ) : (
+          <>
+            <span className="font-semibold">{user.email || user.displayName}</span>
+            <button
+              onClick={logout}
+              className="px-4 py-2 bg-emerald-500 hover:bg-emerald-400 text-gray-900 font-bold rounded"
+            >
+              Sign Out
+            </button>
+          </>
+        )}
+      </div>
+    </nav>
+  );
+}
+
+export default Navbar;


### PR DESCRIPTION
## Summary
- Replace header with responsive navigation bar that shows Home/Dashboard links and auth actions
- Show user email with sign-out when signed in and Sign In/Create Account when signed out
- Introduce footer with basic DOND.FF attribution

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894b43c71108329a9a069c70823ee8b