### PR TITLE
Allow full-width layout and expand dashboard

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,5 @@
 @media only screen and (min-width: 1200px) {
-  body {
+  .content-container {
     margin-left: auto;
     margin-right: auto;
     max-width: 80%;

--- a/src/App.js
+++ b/src/App.js
@@ -17,7 +17,7 @@ function App() {
     <div className="App flex flex-col min-h-screen">
       <Router>
         <Navbar />
-        <div className="flex-grow">
+        <div className="flex-grow content-container">
           <Routes>
             <Route path="/" element={<Home />} />
             <Route path="/login" element={<SignUp />} />

--- a/src/components/dashboard.js
+++ b/src/components/dashboard.js
@@ -118,7 +118,7 @@ const Dashboard = () => {
   };
 
   return (
-    <div className="max-w-4xl mx-auto p-4 space-y-4 text-left bg-[#3a465b]/50 rounded">
+    <div className="mx-auto p-4 space-y-4 text-left bg-[#3a465b]/50 rounded">
       <Breadcrumbs items={[{ label: "Dashboard" }]} />
       <h2 className="text-2xl font-bold">Welcome to Your Dashboard</h2>
       <h3 className="text-xl">{user.email}</h3>


### PR DESCRIPTION
## Summary
- replace body max-width rule with `.content-container` to keep content at 80% while navbar/footer stretch full width
- remove hard max-width constraint from dashboard

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894bc0214548329a11f7b2ad5bb3707