### PR TITLE
feat: add league statistics

### DIFF
--- a/src/components/__tests__/leagueStats.test.js
+++ b/src/components/__tests__/leagueStats.test.js
@@ -1,0 +1,18 @@
+const { calculateStats } = require('../statsUtil');
+
+describe('calculateStats', () => {
+  test('computes wins and highest lineup', () => {
+    const week1 = [
+      { id: 'user1', finalScore: 10, lineUp: {} },
+      { id: 'user2', finalScore: 20, lineUp: {} },
+    ];
+    const week2 = [
+      { id: 'user1', finalScore: 30, lineUp: {} },
+      { id: 'user2', finalScore: 25, lineUp: {} },
+    ];
+    const { winsMap, highEntry } = calculateStats([week1, week2]);
+    expect(winsMap).toEqual({ user2: 1, user1: 1 });
+    expect(highEntry.id).toBe('user1');
+    expect(highEntry.finalScore).toBe(30);
+  });
+});

--- a/src/components/league.js
+++ b/src/components/league.js
@@ -5,6 +5,7 @@ import { doc, onSnapshot } from "firebase/firestore";
 import { onAuthStateChanged } from "firebase/auth";
 import Seasons from "./seasons";
 import Breadcrumbs from "./breadcrumbs";
+import LeagueStats from "./leagueStats";
 
 const League = () => {
 
@@ -67,6 +68,7 @@ const League = () => {
       )}
       <h4 className="text-lg font-semibold">Seasons:</h4>
       <Seasons leagueId={leagueId} />
+      <LeagueStats leagueId={leagueId} league={league} />
       {member?.role === "player" && league.currentSeason && league.currentWeek && (
         <Link
           to="/game/setting-lineups"

--- a/src/components/leagueStats.js
+++ b/src/components/leagueStats.js
@@ -1,0 +1,143 @@
+import React, { useEffect, useState } from "react";
+import { collection, getDocs } from "firebase/firestore";
+import { db } from "../firebase-config";
+import { calculateStats } from "./statsUtil";
+
+const LeagueStats = ({ leagueId, league }) => {
+  const [leagueWins, setLeagueWins] = useState([]);
+  const [seasonWins, setSeasonWins] = useState([]);
+  const [leagueHigh, setLeagueHigh] = useState(null);
+  const [seasonHigh, setSeasonHigh] = useState(null);
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      if (!leagueId) return;
+      const membersSnap = await getDocs(
+        collection(db, "leagues", leagueId, "members")
+      );
+      const memberMap = {};
+      membersSnap.forEach((d) => {
+        const data = d.data();
+        memberMap[d.id] =
+          data.displayName || data.email || data.uid || d.id;
+      });
+
+      const seasonsSnap = await getDocs(
+        collection(db, "leagues", leagueId, "seasons")
+      );
+      let allWeeks = [];
+      let currentSeasonWeeks = [];
+      for (const seasonDoc of seasonsSnap.docs) {
+        const seasonId = seasonDoc.id;
+        const weeksSnap = await getDocs(
+          collection(db, "leagues", leagueId, "seasons", seasonId, "weeks")
+        );
+        for (const weekDoc of weeksSnap.docs) {
+          const entriesSnap = await getDocs(
+            collection(
+              db,
+              "leagues",
+              leagueId,
+              "seasons",
+              seasonId,
+              "weeks",
+              weekDoc.id,
+              "entries"
+            )
+          );
+          const entries = entriesSnap.docs.map((e) => ({
+            id: e.id,
+            ...e.data(),
+          }));
+          if (entries.length > 0) {
+            allWeeks.push(entries);
+            if (seasonId === league.currentSeason) {
+              currentSeasonWeeks.push(entries);
+            }
+          }
+        }
+      }
+      const leagueStats = calculateStats(allWeeks);
+      const seasonStats = calculateStats(currentSeasonWeeks);
+
+      const leagueWinsArr = Object.entries(leagueStats.winsMap)
+        .map(([id, wins]) => ({ id, wins, label: memberMap[id] || id }))
+        .sort((a, b) => b.wins - a.wins);
+      const seasonWinsArr = Object.entries(seasonStats.winsMap)
+        .map(([id, wins]) => ({ id, wins, label: memberMap[id] || id }))
+        .sort((a, b) => b.wins - a.wins);
+
+      if (leagueStats.highEntry) {
+        leagueStats.highEntry.label =
+          memberMap[leagueStats.highEntry.id] || leagueStats.highEntry.id;
+      }
+      if (seasonStats.highEntry) {
+        seasonStats.highEntry.label =
+          memberMap[seasonStats.highEntry.id] || seasonStats.highEntry.id;
+      }
+
+      setLeagueWins(leagueWinsArr);
+      setSeasonWins(seasonWinsArr);
+      setLeagueHigh(leagueStats.highEntry);
+      setSeasonHigh(seasonStats.highEntry);
+    };
+    fetchStats();
+  }, [leagueId, league.currentSeason]);
+
+  const renderWins = (wins) => (
+    <ul className="list-disc list-inside">
+      {wins.map((w) => (
+        <li key={w.id}>
+          {w.label}: {w.wins}
+        </li>
+      ))}
+    </ul>
+  );
+
+  const renderHigh = (entry) => (
+    <div>
+      <div className="font-semibold">{entry.label} - {entry.finalScore} pts</div>
+      <div>
+        RB: {entry.lineUp?.RB?.name} ({entry.lineUp?.RB?.points} proj / {""}
+        {entry.lineUp?.RB?.pprScore || 0} actual)
+      </div>
+      <div>
+        WR: {entry.lineUp?.WR?.name} ({entry.lineUp?.WR?.points} proj / {""}
+        {entry.lineUp?.WR?.pprScore || 0} actual)
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="space-y-4">
+      <h4 className="text-lg font-semibold">League Stats</h4>
+      <div>
+        <h5 className="font-semibold">Win Totals</h5>
+        {renderWins(leagueWins)}
+      </div>
+      {leagueHigh && (
+        <div>
+          <h5 className="font-semibold">Highest Scoring Lineup</h5>
+          {renderHigh(leagueHigh)}
+        </div>
+      )}
+      {league.currentSeason && (
+        <div className="space-y-2">
+          <h4 className="text-lg font-semibold">Current Season Stats</h4>
+          <div>
+            <h5 className="font-semibold">Win Totals</h5>
+            {renderWins(seasonWins)}
+          </div>
+          {seasonHigh && (
+            <div>
+              <h5 className="font-semibold">Highest Scoring Lineup</h5>
+              {renderHigh(seasonHigh)}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default LeagueStats;

--- a/src/components/statsUtil.js
+++ b/src/components/statsUtil.js
@@ -1,0 +1,25 @@
+export const calculateStats = (weeks) => {
+  const winsMap = {};
+  let highEntry = null;
+  weeks.forEach((entries) => {
+    if (!entries || entries.length === 0) return;
+    const sorted = [...entries].sort(
+      (a, b) => (b.finalScore || 0) - (a.finalScore || 0)
+    );
+    const winner = sorted[0];
+    if (winner) {
+      winsMap[winner.id] = (winsMap[winner.id] || 0) + 1;
+    }
+    sorted.forEach((entry) => {
+      if (
+        !highEntry ||
+        (entry.finalScore || 0) > (highEntry.finalScore || 0)
+      ) {
+        highEntry = entry;
+      }
+    });
+  });
+  return { winsMap, highEntry };
+};
+
+export default calculateStats;


### PR DESCRIPTION
## Summary
- add LeagueStats component and stats utility to compute wins and top lineups
- show league and season win totals and high scoring lineups in league view
- test stats utility

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894cdf2c7dc8329bbf78ac7fcd9feac