### PR TITLE
Fix #45 - only allowing a single reset, instead of one for each position

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="b33569a5-9a23-4aef-b23f-839075863726" name="Changes" comment="">
+      <change afterPath="$PROJECT_DIR$/.idea/codeStyles/codeStyleConfig.xml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/.idea/vcs.xml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="ProjectColorInfo">{
+  &quot;associatedIndex&quot;: 8
+}</component>
+  <component name="ProjectId" id="321N3NPdOiTjVMhIoPZPq4dZnRP" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ASKED_SHARE_PROJECT_CONFIGURATION_FILES": "true",
+    "Jest.All Tests.executor": "Run",
+    "Jest.Tests in __tests__/.executor": "Run",
+    "ModuleVcsDetector.initialDetectionPerformed": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
+    "git-widget-placeholder": "main",
+    "last_opened_file_path": "/Users/belcheti/projects/dondff",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs.jest.jest_package": "/Users/belcheti/projects/dondff/node_modules/react-scripts",
+    "nodejs_package_manager_path": "npm",
+    "settings.editor.selected.configurable": "preferences.sourceCode.JavaScript",
+    "ts.external.directory.path": "/Users/belcheti/Applications/WebStorm.app/Contents/plugins/javascript-plugin/jsLanguageServicesImpl/external",
+    "vue.rearranger.settings.migration": "true"
+  }
+}]]></component>
+  <component name="RunManager" selected="Jest.All Tests">
+    <configuration name="All Tests" type="JavaScriptTestRunnerJest" temporary="true" nameIsGenerated="true">
+      <node-interpreter value="project" />
+      <jest-package value="$PROJECT_DIR$/node_modules/react-scripts" />
+      <working-dir value="$PROJECT_DIR$" />
+      <envs />
+      <scope-kind value="ALL" />
+      <method v="2" />
+    </configuration>
+    <configuration name="Tests in __tests__/" type="JavaScriptTestRunnerJest" temporary="true" nameIsGenerated="true">
+      <node-interpreter value="project" />
+      <jest-package value="$PROJECT_DIR$/node_modules/react-scripts" />
+      <working-dir value="$PROJECT_DIR$" />
+      <envs />
+      <scope-kind value="DIRECTORY" />
+      <test-directory value="$PROJECT_DIR$/src/components/__tests__" />
+      <method v="2" />
+    </configuration>
+    <recent_temporary>
+      <list>
+        <item itemvalue="Jest.All Tests" />
+        <item itemvalue="Jest.Tests in __tests__/" />
+      </list>
+    </recent_temporary>
+  </component>
+  <component name="SharedIndexes">
+    <attachedChunks>
+      <set>
+        <option value="bundled-js-predefined-d6986cc7102b-b598e85cdad2-JavaScript-WS-252.25557.126" />
+      </set>
+    </attachedChunks>
+  </component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="b33569a5-9a23-4aef-b23f-839075863726" name="Changes" comment="" />
+      <created>1756583918838</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1756583918838</updated>
+      <workItem from="1756583920253" duration="172000" />
+      <workItem from="1756584101976" duration="3797000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="Vcs.Log.Tabs.Properties">
+    <option name="TAB_STATES">
+      <map>
+        <entry key="MAIN">
+          <value>
+            <State>
+              <option name="FILTERS">
+                <map>
+                  <entry key="branch">
+                    <value>
+                      <list>
+                        <option value="origin/main" />
+                      </list>
+                    </value>
+                  </entry>
+                </map>
+              </option>
+            </State>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+  <component name="VcsManagerConfiguration">
+    <MESSAGE value="stashing while I try to rebase" />
+    <option name="LAST_COMMIT_MESSAGE" value="stashing while I try to rebase" />
+  </component>
+</project>

--- a/src/components/__tests__/entries.test.js
+++ b/src/components/__tests__/entries.test.js
@@ -35,8 +35,8 @@ test('calculateScores sums player scores and persists finalScore', async () => {
       id: 'entry2',
       name: 'Entry Two',
       lineUp: {
-        RB: { playerId: 'rb1', pprScore: 0, name: 'RB1' },
-        WR: { playerId: 'wr1', pprScore: 0, name: 'WR1' },
+        RB: { playerId: 'rb2', pprScore: 0, name: 'RB2' },
+        WR: { playerId: 'wr2', pprScore: 0, name: 'WR2' },
       },
     },
   ];
@@ -49,10 +49,16 @@ test('calculateScores sums player scores and persists finalScore', async () => {
   global.fetch = jest
     .fn()
     .mockResolvedValueOnce({
-      json: async () => [{ player_id: 'rb1', stats: { pts_ppr: 10 } }],
+      json: async () => [
+        {player_id: 'rb1', stats: {pts_ppr: 10}},
+        {player_id: 'rb2', stats: {pts_ppr: 11.1}}
+      ],
     })
     .mockResolvedValueOnce({
-      json: async () => [{ player_id: 'wr1', stats: { pts_ppr: 20 } }],
+      json: async () => [
+        {player_id: 'wr1', stats: {pts_ppr: 20}},
+        {player_id: 'wr2', stats: {pts_ppr: 19.06666}}
+      ],
     });
 
   doc.mockImplementation(
@@ -70,14 +76,11 @@ test('calculateScores sums player scores and persists finalScore', async () => {
 
   await waitFor(() => expect(setDoc).toHaveBeenCalledTimes(dummyEntries.length));
 
-  dummyEntries.forEach((entry, index) => {
-    expect(entry.finalScore).toBe(30);
-    expect(setDoc.mock.calls[index][1]).toEqual({
-      name: entry.name,
-      lineUp: entry.lineUp,
-      finalScore: entry.finalScore,
-    });
-  });
+  expect(dummyEntries.length).toBe(2);
+  expect(dummyEntries[0].id).toBe('entry1');
+  expect(dummyEntries[0].finalScore).toBe(30);
+  expect(dummyEntries[1].id).toBe('entry2');
+  expect(dummyEntries[1].finalScore).toBe(30.16666); //Don't round on the backend, round on the display
 });
 
 test('memberLabel prioritizes displayName then email then id', () => {
@@ -112,8 +115,8 @@ test('renders projection columns and values', () => {
     {
       id: 'user1',
       lineUp: {
-        RB: { name: 'RB1', points: 12 },
-        WR: { name: 'WR1', points: 8 },
+        RB: { name: 'RB1', points: 12.001 },
+        WR: { name: 'WR1', points: 8.002 },
       },
     },
   ];

--- a/src/components/game.js
+++ b/src/components/game.js
@@ -109,14 +109,15 @@ const Game = ({ uid, onComplete }) => {
     }
   }
 
-  const resetGame = (pos = type, consume = true) => {
-    if (consume && (caseSelected || resetUsed[pos])) return
+  const resetGame = (consume = true) => {
+    if (consume && (caseSelected || resetUsed[type])) return
     if (consume) {
-      setResetUsed(prev => ({ ...prev, [pos]: true }))
+      resetUsed[type] = true;
+      setResetUsed(resetUsed);
     }
     setReset(true)
     setMidway(false)
-    setLineUp(prev => ({ ...prev, [pos]: { name: "awaiting game..." } }))
+    setLineUp(prev => ({ ...prev, [type]: { name: "awaiting game..." } }))
   }
   
   const removeCases = (arr, n) => {
@@ -284,7 +285,7 @@ const Game = ({ uid, onComplete }) => {
     setPool([])
     setType("WR")
     setLimit(95)
-    resetGame("WR", false)
+    resetGame(false)
     setFinished(true)
   }
 

--- a/src/components/weeks.js
+++ b/src/components/weeks.js
@@ -12,14 +12,7 @@ const Weeks = () => {
   const [actualNFLWeek, setActualNFLWeek] = useState(null);
   const [leagueName, setLeagueName] = useState("");
 
-  const leagueCollection = collection(
-    db,
-    "leagues",
-    leagueId,
-    "seasons",
-    season,
-    "weeks"
-  );
+  const leagueCollection = collection(db, "leagues", leagueId, "seasons", season, "weeks");
   const [docs, loading] = useCollectionData(leagueCollection);
 
   useEffect(() => {
@@ -44,15 +37,7 @@ const Weeks = () => {
 
   const addWeek = async () => {
     try {
-      const docRef = doc(
-        db,
-        "leagues",
-        leagueId,
-        "seasons",
-        season,
-        "weeks",
-        week
-      );
+      const docRef = doc(db, "leagues", leagueId, "seasons", season, "weeks", week);
       await setDoc(docRef, {
         week: week,
       });
@@ -76,7 +61,7 @@ const Weeks = () => {
       />
       {loading && "Loading..."}
       <div className="space-y-4 max-w-[90%] mx-auto">
-        {docs?.map((weekDoc) => (
+        {docs?.sort((a, b) => a.week - b.week).map((weekDoc) => (
           <Accordion
             key={weekDoc.week}
             weekDoc={weekDoc}


### PR DESCRIPTION
There's some weird stuff going on still - when debugging, the default consume=true is showing up as an object, and I have some doubts that the lineup setting here is doing what it's supposed to do, but I also don't know what that is, so... /shrug